### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,14 +13,30 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: "Build"
-    uses: dockette/.github/.github/workflows/docker.yml@master
-    secrets: inherit
-    with:
-        image: "dockette/web"
-        tag: "${{ matrix.tag }}"
-        context: "${{ matrix.context }}"
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: "${{ matrix.context }}"
+          push: false
+          tags: "dockette/web:${{ matrix.tag }}"
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+
+      - name: Test image
+        run: make _docker-test-${{ matrix.tag }}
+
     strategy:
       matrix:
         include:
@@ -35,3 +51,44 @@ jobs:
           - { context: debian-php-83, tag: php-83 }
           - { context: debian-php-84, tag: php-84 }
           - { context: debian-php-85, tag: php-85 }
+
+  build:
+    name: "Build"
+    needs: test
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/web"
+      tag: "${{ matrix.tag }}"
+      context: "${{ matrix.context }}"
+      push: ${{ github.ref == 'refs/heads/master' }}
+    strategy:
+      matrix:
+        include:
+          - { context: debian-php-70, tag: php-70 }
+          - { context: debian-php-71, tag: php-71 }
+          - { context: debian-php-72, tag: php-72 }
+          - { context: debian-php-73, tag: php-73 }
+          - { context: debian-php-74, tag: php-74 }
+          - { context: debian-php-80, tag: php-80 }
+          - { context: debian-php-81, tag: php-81 }
+          - { context: debian-php-82, tag: php-82 }
+          - { context: debian-php-83, tag: php-83 }
+          - { context: debian-php-84, tag: php-84 }
+          - { context: debian-php-85, tag: php-85 }
+
+  docs:
+    name: "Docs"
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: dockette/web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,38 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Dockette Web publishes ready-to-use Debian-based web images for PHP applications with Nginx, PHP-FPM, Supervisor, Cron, Composer, and a default `/srv/www` site.
+
+## Images
+
+- Docker image: `dockette/web`.
+- Default Makefile tag: `php-85`.
+- Tags and build contexts: `php-70` through `php-74`, plus `php-80` through `php-85`, built from `./debian-<tag>`.
+- All current Dockerfiles use `dockette/debian:bookworm` and packages from `packages.sury.org/php` plus nginx.org packages.
+- `.templates/` contains shared nginx, PHP, supervisor, entrypoint, and default web files copied by `make templates`.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make templates` copies `.templates/` into every versioned build context.
+- `make build` builds all PHP tags.
+- `make test` runs all Docker smoke tests.
+- `make run` starts `${DOCKER_IMAGE}:${DOCKER_TAG}` on host port `8000`.
+- `make _docker-test-php-85` builds no image; it starts the already-built tag, waits, and verifies `http://localhost:8000/` with curl.
+- Override `DOCKER_TAG` or `DOCKER_IMAGE` when testing a single tag.
+
+## Runtime Notes
+
+- There are no compose files in this repository.
+- Containers expose port `80`; the Makefile maps it to host `8000`.
+- Custom Nginx config is expected at `/etc/nginx/sites.d/site.conf`.
+- Cron files can be mounted at `/etc/cron.d/app` and must include the username column, for example `www-data`.
+- The entrypoint starts services through Supervisor; keep PHP-FPM, nginx, cron, and supervisor config paths consistent across all version directories.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep README tag tables, Makefile targets, workflow matrices, and versioned directories aligned when adding or removing PHP versions.
+- Update `.templates/` first for shared config changes, then regenerate or intentionally sync each `debian-php-*` context.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
-- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Avoid changing exposed ports, `/srv` layout, or config mount paths unless the README and tests are updated with the same behavior.
 - Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 DOCKER_IMAGE=dockette/web
 DOCKER_TAG?=php-85
 
-.PHONY: templates build test run docker-build-all docker-test-all
 
+.PHONY: templates
 templates:
 	cp -R .templates/ debian-php-70
 	cp -R .templates/ debian-php-71
@@ -17,31 +17,47 @@ templates:
 	cp -R .templates/ debian-php-85
 
 _docker-build-%: VERSION=$*
+.PHONY: _docker-build-%
 _docker-build-%:
 	docker buildx build \
 		--pull \
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./debian-${VERSION}
 
+.PHONY: docker-build-php-70
 docker-build-php-70: _docker-build-php-70
+.PHONY: docker-build-php-71
 docker-build-php-71: _docker-build-php-71
+.PHONY: docker-build-php-72
 docker-build-php-72: _docker-build-php-72
+.PHONY: docker-build-php-73
 docker-build-php-73: _docker-build-php-73
+.PHONY: docker-build-php-74
 docker-build-php-74: _docker-build-php-74
+.PHONY: docker-build-php-80
 docker-build-php-80: _docker-build-php-80
+.PHONY: docker-build-php-81
 docker-build-php-81: _docker-build-php-81
+.PHONY: docker-build-php-82
 docker-build-php-82: _docker-build-php-82
+.PHONY: docker-build-php-83
 docker-build-php-83: _docker-build-php-83
+.PHONY: docker-build-php-84
 docker-build-php-84: _docker-build-php-84
+.PHONY: docker-build-php-85
 docker-build-php-85: _docker-build-php-85
 
+.PHONY: build
 build: docker-build-all
 
+.PHONY: test
 test: docker-test-all
 
+.PHONY: run
 run:
 	docker run --rm -it --name dockette-web -p 8000:80 ${DOCKER_IMAGE}:${DOCKER_TAG}
 
+.PHONY: docker-build-all
 docker-build-all:
 	$(MAKE) docker-build-php-70
 	$(MAKE) docker-build-php-71
@@ -56,6 +72,7 @@ docker-build-all:
 	$(MAKE) docker-build-php-85
 
 
+.PHONY: docker-test-all
 docker-test-all:
 	$(MAKE) _docker-test-php-70
 	$(MAKE) _docker-test-php-71
@@ -70,6 +87,7 @@ docker-test-all:
 	$(MAKE) _docker-test-php-85
 
 _docker-test-%: VERSION=$*
+.PHONY: _docker-test-%
 _docker-test-%:
 	set -e; \
 	container="dockette-web-${VERSION}"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_IMAGE=dockette/web
+DOCKER_TAG?=php-85
 
 .PHONY: templates build test run docker-build-all docker-test-all
 
@@ -39,7 +40,7 @@ build: docker-build-all
 test: docker-test-all
 
 run:
-	docker run --rm -it --name dockette-web -p 8000:80 ${DOCKER_IMAGE}:php-85
+	docker run --rm -it --name dockette-web -p 8000:80 ${DOCKER_IMAGE}:${DOCKER_TAG}
 
 docker-build-all:
 	$(MAKE) docker-build-php-70

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DOCKER_IMAGE=dockette/web
 
+.PHONY: templates build test run docker-build-all docker-test-all
+
 templates:
 	cp -R .templates/ debian-php-70
 	cp -R .templates/ debian-php-71
@@ -32,6 +34,13 @@ docker-build-php-83: _docker-build-php-83
 docker-build-php-84: _docker-build-php-84
 docker-build-php-85: _docker-build-php-85
 
+build: docker-build-all
+
+test: docker-test-all
+
+run:
+	docker run --rm -it --name dockette-web -p 8000:80 ${DOCKER_IMAGE}:php-85
+
 docker-build-all:
 	$(MAKE) docker-build-php-70
 	$(MAKE) docker-build-php-71
@@ -61,7 +70,10 @@ docker-test-all:
 
 _docker-test-%: VERSION=$*
 _docker-test-%:
-	docker run --rm -d --name dockette-web-${VERSION} -p 8000:80 ${DOCKER_IMAGE}:${VERSION}
-	sleep 5
+	set -e; \
+	container="dockette-web-${VERSION}"; \
+	docker rm -f "$${container}" >/dev/null 2>&1 || true; \
+	trap 'docker rm -f "$${container}" >/dev/null 2>&1 || true' EXIT; \
+	docker run --rm -d --name "$${container}" -p 8000:80 ${DOCKER_IMAGE}:${VERSION}; \
+	sleep 5; \
 	curl -f -Li localhost:8000
-	docker stop dockette-web-${VERSION}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project provides ready-to-use Docker images for web development and deploym
 
 ### Key Features
 
-- **Multiple PHP Versions**: Support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5
+- **Multiple PHP Versions**: Support for PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5; older EOL tags are retained for compatibility
 - **Nginx Web Server**: Pre-configured with sensible defaults for PHP applications
 - **PHP-FPM**: Optimized for performance with common extensions installed
 - **Supervisor**: Process control system to manage services
@@ -48,16 +48,26 @@ This project provides ready-to-use Docker images for web development and deploym
 | `dockette/web:php-71` | Bookworm | 7.1 |
 | `dockette/web:php-70` | Bookworm | 7.0 |
 
+PHP 7.0 through 8.1 are outside upstream active/security support and are kept here for compatibility with legacy applications. Prefer a maintained PHP tag for new projects.
+
 You can easily start your Docker container with following command.
 
 ```
 docker run \
 	-it \
 	--rm \
-	--name www \
-	-p 80:80 \
+	--name dockette-web \
+	-p 8000:80 \
 	dockette/web:php-85
 ```
+
+This matches the default `make run` behavior and serves the container on `http://localhost:8000/`.
+
+### Makefile commands
+
+- `make build` builds all PHP tags for `dockette/web`.
+- `make test` runs Docker smoke tests for all tags and checks `http://localhost:8000/`.
+- `make run` starts `${DOCKER_IMAGE}:${DOCKER_TAG}` with default tag `php-85`, container name `dockette-web`, and port mapping `8000:80`.
 
 ### Custom Nginx config
 
@@ -68,9 +78,9 @@ in such way:
 docker run \
 	-it \
 	--rm \
-	--name www \
+	--name dockette-web \
 	-v my-lovely-nginx.conf:/etc/nginx/sites.d/site.conf \
-	-p 80:80 \
+	-p 8000:80 \
 	dockette/web:php-85
 ```
 
@@ -83,9 +93,9 @@ in such way:
 docker run \
 	-it \
 	--rm \
-	--name www \
+	--name dockette-web \
 	-v my-crontab:/etc/cron.d/app \
-	-p 80:80 \
+	-p 8000:80 \
 	dockette/web:php-85
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 </p>
 
 <p align=center>
-  <a href="https://hub.docker.com/r/dockette/web/"><img src="https://badgen.net/docker/pulls/dockette/web"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://github.com/sponsors/f3l1x"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+   <a href="https://github.com/dockette/web/actions"><img src="https://github.com/dockette/web/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/web"><img src="https://img.shields.io/docker/pulls/dockette/web.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 ![](https://github.com/dockette/web/blob/master/screenshot.png "It works")
@@ -96,4 +97,5 @@ There is also username, for example:
 ```
 
 ## Maintenance
+
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/debian-php-85/Dockerfile
+++ b/debian-php-85/Dockerfile
@@ -52,9 +52,12 @@ RUN apt update && apt dist-upgrade -y && \
         php8.5-ssh2 \
         php8.5-tidy \
         php8.5-zip \
-        php8.5-xmlrpc \
         php8.5-xsl && \
-    if apt-cache show php8.5-memcached > /dev/null 2>&1; then apt install -y --no-install-recommends php8.5-memcached; fi && \
+    for extension in memcached xmlrpc; do \
+        if apt-cache show "php8.5-${extension}" > /dev/null 2>&1; then \
+            apt install -y --no-install-recommends "php8.5-${extension}"; \
+        fi; \
+    done && \
     # COMPOSER #################################################################
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2 && \
     # NGINX ####################################################################


### PR DESCRIPTION
What changed\n- Added baseline Makefile aliases for build, test, and run.\n- Added safe test container cleanup around curl smoke tests.\n- Added a CI Test job before the reusable Build job and a Docker Hub Docs job.\n- Normalized README badges to the dockette/copybara style and kept the standard Maintenance section.\n\nWhy\n- Aligns dockette/web with the Dockette CI rollout baseline while keeping builds and docs publishing gated through the existing Docker workflow.